### PR TITLE
Fix ore generation:

### DIFF
--- a/jni/com/byteandahalf/ports/gc/core/GalacticraftCore.cpp
+++ b/jni/com/byteandahalf/ports/gc/core/GalacticraftCore.cpp
@@ -20,27 +20,16 @@ void Block$initBlocks() {
 	GCBlocks::initBlocks();
 }
 
-BiomeDecorator* (*_BiomeDecorator$BiomeDecorator)(BiomeDecorator*);
-BiomeDecorator* BiomeDecorator$BiomeDecorator(BiomeDecorator* self) {
-	BiomeDecorator* retval = _BiomeDecorator$BiomeDecorator(self);
-	GCFeatures::setDecorator(retval);
-	GCFeatures::initFeatures();
-	return retval;
-}
-
 void (*_BiomeDecorator$decorateOres)(BiomeDecorator*, BlockSource*, Random&, const BlockPos&);
 void BiomeDecorator$decorateOres(BiomeDecorator* self, BlockSource* region, Random& random, const BlockPos& pos) {
 	_BiomeDecorator$decorateOres(self, region, random, pos);
 	
-	GCFeatures::populateFeatures(region, random, pos);
+	GCFeatures::populateFeatures(self, region, random, pos);
 }
 
 JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 	MSHookFunction((void*) &Block::initBlocks, (void*) &Block$initBlocks, (void**) &_Block$initBlocks);
 	MSHookFunction((void*) &BiomeDecorator::decorateOres, (void*) &BiomeDecorator$decorateOres, (void**) &_BiomeDecorator$decorateOres);
-	
-	void* BiomeDecorator$$BiomeDecorator = (void*) dlsym(RTLD_DEFAULT, "_ZN14BiomeDecoratorC2Ev");
-	MSHookFunction(BiomeDecorator$$BiomeDecorator, (void*) &BiomeDecorator$BiomeDecorator, (void**) &_BiomeDecorator$BiomeDecorator);
 
 	return JNI_VERSION_1_2;
 }

--- a/jni/com/byteandahalf/ports/gc/core/world/wgen/GCFeatureInfo.cpp
+++ b/jni/com/byteandahalf/ports/gc/core/world/wgen/GCFeatureInfo.cpp
@@ -1,8 +1,8 @@
 #include "GCFeatureInfo.h"
 
-GCFeatureInfo::GCFeatureInfo(GCFeatureInfo::GenType gentype, std::unique_ptr<Feature>& feature, int amountPerChunk, int minY, int maxY) :
+GCFeatureInfo::GCFeatureInfo(GCFeatureInfo::GenType gentype, std::unique_ptr<Feature> feature, int amountPerChunk, int minY, int maxY) :
 	gentype(gentype),
-	feature(feature),
+	feature(std::move(feature)),
 	amountPerChunk(amountPerChunk),
 	minY(minY),
 	maxY(maxY) {

--- a/jni/com/byteandahalf/ports/gc/core/world/wgen/GCFeatureInfo.h
+++ b/jni/com/byteandahalf/ports/gc/core/world/wgen/GCFeatureInfo.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <memory>
+#include "com/mojang/minecraftpe/world/level/levelgen/feature/Feature.h"
 class Feature;
 
 struct GCFeatureInfo {
@@ -8,10 +9,10 @@ struct GCFeatureInfo {
 		AVERAGE
 	};
 	
-	GCFeatureInfo(GCFeatureInfo::GenType, std::unique_ptr<Feature>&, int, int, int);
+	GCFeatureInfo(GCFeatureInfo::GenType, std::unique_ptr<Feature>, int, int, int);
 	
 	GCFeatureInfo::GenType gentype;
-	std::unique_ptr<Feature>& feature;
+	std::unique_ptr<Feature> feature;
 	int amountPerChunk;
 	int minY;
 	int maxY;

--- a/jni/com/byteandahalf/ports/gc/core/world/wgen/GCFeatures.cpp
+++ b/jni/com/byteandahalf/ports/gc/core/world/wgen/GCFeatures.cpp
@@ -3,39 +3,27 @@
 #include "com/mojang/minecraftpe/world/level/levelgen/feature/OreFeature.h"
 #include "GCFeatureInfo.h"
 
-BiomeDecorator* GCFeatures::Decorator;
 std::vector<GCFeatureInfo> GCFeatures::features;
 
-std::unique_ptr<Feature> GCFeatures::testFeature;
-
-void GCFeatures::setDecorator(BiomeDecorator* decorator) {
-	Decorator = decorator;
-}
-
-void GCFeatures::flushFeatures() {
-	// Delete existing instances of each Feature
-	delete testFeature.release();
-}
-
 void GCFeatures::initFeatures() {
-	// Init unique_ptrs for features
-	flushFeatures();
-	
-	//testFeature.reset(new OreFeature(19, 0, 12));
-	
+	static bool inited = false;
+	if (inited) return;
+	inited = true;
 	registerFeatures();
 }
 
 void GCFeatures::registerFeatures() {
 	// Create FeatureInfo and push to the global feature vector
-	//features.push_back(GCFeatureInfo(GCFeatureInfo::GenType::SPAN, testFeature, 20, 0, 128));
+	features.emplace_back(GCFeatureInfo::GenType::SPAN,
+		std::unique_ptr<Feature>(new OreFeature(19, 0, 12)), 20, 0, 128);
 }
 
-void GCFeatures::populateFeatures(BlockSource* region, Random& random, const BlockPos& pos) {
+void GCFeatures::populateFeatures(BiomeDecorator* decorator, BlockSource* region, Random& random, const BlockPos& pos) {
+	GCFeatures::initFeatures();
 	for(GCFeatureInfo& fe : features) {
 		if(fe.gentype == GCFeatureInfo::GenType::SPAN)
-			Decorator->decorateDepthSpan(region, random, pos, fe.amountPerChunk, fe.feature, fe.minY, fe.maxY);
+			decorator->decorateDepthSpan(region, random, pos, fe.amountPerChunk, fe.feature, fe.minY, fe.maxY);
 		else if(fe.gentype == GCFeatureInfo::GenType::AVERAGE)
-			Decorator->decorateDepthAverage(region, random, pos, fe.amountPerChunk, fe.feature, fe.minY, fe.maxY);
+			decorator->decorateDepthAverage(region, random, pos, fe.amountPerChunk, fe.feature, fe.minY, fe.maxY);
 	}
 }

--- a/jni/com/byteandahalf/ports/gc/core/world/wgen/GCFeatures.h
+++ b/jni/com/byteandahalf/ports/gc/core/world/wgen/GCFeatures.h
@@ -9,16 +9,11 @@ class Feature;
 class GCFeatureInfo;
 
 class GCFeatures {
-	static BiomeDecorator* Decorator;
 	static std::vector<GCFeatureInfo> features;
 	
-	static std::unique_ptr<Feature> testFeature;
-	
 public:
-	static void setDecorator(BiomeDecorator*);
-	static void flushFeatures();
 	static void initFeatures();
 	static void registerFeatures();
-	static void populateFeatures(BlockSource*, Random&, const BlockPos&);
+	static void populateFeatures(BiomeDecorator*, BlockSource*, Random&, const BlockPos&);
 };
 


### PR DESCRIPTION
I'm not that good with unique_ptrs, so might want to get c0deh4cker to take a look and see if what I'm doing is sensible
- Pass active BiomeDecorator to GCFeatures::populateFeatures since each biome has its own decorator
- Remove global variable for each feature and keep them inside GCFeatureInfo instead
- Initialize features only once instead of every time a new Biome is constructed
- use emplace_back instead of push_back and constructor since it looks nicer
